### PR TITLE
Add handshake and packet size metrics with threat logging

### DIFF
--- a/src/threat/mod.rs
+++ b/src/threat/mod.rs
@@ -2,6 +2,7 @@ pub mod ratelimit;
 
 use std::{future::IntoFuture, time::Duration};
 
+use log::warn;
 use tokio::time::{error::Elapsed, timeout};
 
 use crate::threat::ratelimit::RateLimitResult;
@@ -45,7 +46,13 @@ impl ThreatControlService {
     {
         match timeout(intent.duration, future.into_future()).await {
             Ok(v) => Ok(v),
-            Err(elapsed) => Err(ClientFail::Timeout { intent, elapsed }.into()),
+            Err(elapsed) => {
+                warn!(
+                    "Client {:?} timed out after {:?}",
+                    intent.tag, intent.duration
+                );
+                Err(ClientFail::Timeout { intent, elapsed }.into())
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- record packet size via histogram metric
- track handshake duration and log completion time
- log threat timeouts and rate limit violations

## Testing
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689c7be7bc308327ac54346fa524b67f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added telemetry histograms to track per-packet sizes and handshake duration for better observability.

- Chores
  - Introduced warning logs for rate-limit breaches and threat timeouts to aid troubleshooting.
  - Tightened requirements on rate-limiter key types to support richer logging; may require minor configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->